### PR TITLE
closes #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,16 @@ class RandomGenerator {
 
     // To handle edge cases
     this.handleEdgeCases();
-    let trulyRandomNumber = this.generateUniqueNumber();
+
+    let trulyRandomNumber;
+
+    while (true) {
+      trulyRandomNumber = this.generateUniqueNumber();
+
+      if (trulyRandomNumber !== 0n) {
+        break;
+      }
+    }
 
     trulyRandomNumber = this.increaseLength(trulyRandomNumber, maxGroups);
 

--- a/test/generator.js
+++ b/test/generator.js
@@ -17,6 +17,13 @@ describe("RandomGenerator", () => {
 
       expect(randomString).to.have.lengthOf(20);
     });
+
+    it("should generate a string of length (33) if passed to generate", () => {
+      const generator = new RandomGenerator();
+      const randomString = generator.generate(33);
+
+      expect(randomString).to.have.lengthOf(33);
+    });
   });
 
   describe("#String output Check", () => {


### PR DESCRIPTION
The generateUniqueNumber() method can sometimes return 0 as the random number. We need to retry generation until we get a non-zero result.

This fix includes a while loop that will continuously call generateUniqueNumber() and check if the result is 0. If so, it will loop again to generate a new number. This ensures we handle the edge case and don't return 0.